### PR TITLE
Add JudgeAgent with demo and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Run the test suite:
 pytest tests/
 ```
 
+### Judge Agent Demo
+
+To demonstrate diary logging and knowledge graph updates, run:
+
+```bash
+python scripts/demo_judge_review.py
+```
+
+This script sends a sample email using `VertexEmailAgent`, runs `JudgeAgent` to
+verify the entry, prints triple counts before and after, and shows the judge's
+diary entries.
+
 ## License
 
 MIT License - see LICENSE file for details

--- a/agents/domain/__init__.py
+++ b/agents/domain/__init__.py
@@ -6,6 +6,8 @@ from .simple_agents import (
     IntelligenceAgent,
     DeveloperAgent,
 )
+from .vertex_email_agent import VertexEmailAgent
+from .judge_agent import JudgeAgent
 
 __all__ = [
     "CorporateKnowledgeAgent",
@@ -14,4 +16,6 @@ __all__ = [
     "CoachingAgent",
     "IntelligenceAgent",
     "DeveloperAgent",
+    "VertexEmailAgent",
+    "JudgeAgent",
 ]

--- a/agents/domain/judge_agent.py
+++ b/agents/domain/judge_agent.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict
+from datetime import datetime
+
+from agents.core.base_agent import BaseAgent, AgentMessage
+from kg.models.graph_manager import KnowledgeGraphManager
+from loguru import logger
+
+
+class JudgeAgent(BaseAgent):
+    """Agent that evaluates whether actions were properly logged."""
+
+    def __init__(self, agent_id: str = "judge_agent", kg: KnowledgeGraphManager | None = None):
+        super().__init__(agent_id, "judge")
+        self.logger = logger.bind(agent_id=agent_id)
+        self.knowledge_graph = kg
+
+    async def initialize(self) -> None:  # pragma: no cover - simple init
+        self.logger.info("Judge Agent initialized")
+
+    async def process_message(self, message: AgentMessage) -> AgentMessage:
+        if message.message_type == "evaluate_challenge":
+            decision = await self.evaluate_challenge(message.content.get("challenge", ""))
+            return AgentMessage(
+                sender=self.agent_id,
+                recipient=message.sender,
+                content={"decision": decision},
+                timestamp=message.timestamp,
+                message_type="judge_response",
+            )
+        return AgentMessage(
+            sender=self.agent_id,
+            recipient=message.sender,
+            content={"status": "error", "message": "Unknown message type"},
+            timestamp=message.timestamp,
+            message_type="error_response",
+        )
+
+    async def update_knowledge_graph(self, update_data: Dict[str, Any]) -> None:  # pragma: no cover - not used
+        if self.knowledge_graph:
+            await self.knowledge_graph.update_graph(update_data)
+
+    async def query_knowledge_graph(self, query: Dict[str, Any]) -> Dict[str, Any]:  # pragma: no cover - not used
+        if not self.knowledge_graph:
+            return {}
+        return await self.knowledge_graph.query_graph(query.get("sparql", ""))
+
+    async def evaluate_challenge(self, challenge_data: str) -> str:
+        """Check if any email entries exist in the knowledge graph."""
+        if not self.knowledge_graph:
+            decision = "NoGraph"
+        else:
+            results = await self.knowledge_graph.query_graph(
+                "SELECT ?s WHERE {?s ?p ?o . FILTER STRSTARTS(STR(?s), 'email:')}"
+            )
+            decision = "Approved" if results else "Rejected"
+
+        diary_entry = (
+            f"{self.agent_id} evaluated challenge as {decision} at {datetime.utcnow().isoformat()}"
+        )
+        self.write_diary(diary_entry)
+        return decision

--- a/agents/domain/vertex_email_agent.py
+++ b/agents/domain/vertex_email_agent.py
@@ -1,0 +1,70 @@
+from typing import Any, Dict, List
+from agents.core.base_agent import BaseAgent, AgentMessage
+from loguru import logger
+
+class VertexEmailAgent(BaseAgent):
+    """Agent that simulates sending email using Google Vertex AI."""
+
+    def __init__(self, agent_id: str = "vertex_email_agent"):
+        super().__init__(agent_id, "vertex_email")
+        self.sent_emails: List[Dict[str, str]] = []
+        self.logger = logger.bind(agent_id=agent_id)
+
+    async def initialize(self) -> None:
+        """Initialize the agent."""
+        self.logger.info("Vertex Email Agent initialized (simulation)")
+
+    async def process_message(self, message: AgentMessage) -> AgentMessage:
+        if message.message_type == "send_email":
+            email = {
+                "recipient": message.content.get("recipient"),
+                "subject": message.content.get("subject"),
+                "body": message.content.get("body"),
+            }
+            await self.send_email(**email)
+            return AgentMessage(
+                sender=self.agent_id,
+                recipient=message.sender,
+                content={"status": "sent", **email},
+                timestamp=message.timestamp,
+                message_type="send_email_response",
+            )
+        return AgentMessage(
+            sender=self.agent_id,
+            recipient=message.sender,
+            content={"status": "error", "message": "Unknown message type"},
+            timestamp=message.timestamp,
+            message_type="error_response",
+        )
+
+    async def send_email(self, recipient: str, subject: str, body: str) -> None:
+        """Simulate sending an email via Vertex AI."""
+        self.logger.info(
+            f"Simulated sending email to {recipient} with subject '{subject}'"
+        )
+        self.sent_emails.append(
+            {"recipient": recipient, "subject": subject, "body": body}
+        )
+        self.write_diary(
+            f"Sent email to {recipient} with subject '{subject}'",
+            {"body": body},
+        )
+        if self.knowledge_graph:
+            await self.knowledge_graph.update_graph(
+                {
+                    f"email:{len(self.sent_emails)}": {
+                        "recipient": recipient,
+                        "subject": subject,
+                        "body": body,
+                    }
+                }
+            )
+
+    async def update_knowledge_graph(self, update_data: Dict[str, Any]) -> None:
+        if self.knowledge_graph:
+            await self.knowledge_graph.update_graph(update_data)
+
+    async def query_knowledge_graph(self, query: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.knowledge_graph:
+            return {}
+        return await self.knowledge_graph.query_graph(query.get("sparql", ""))

--- a/scripts/demo_judge_review.py
+++ b/scripts/demo_judge_review.py
@@ -1,0 +1,38 @@
+import asyncio
+from agents.domain.vertex_email_agent import VertexEmailAgent
+from agents.domain.judge_agent import JudgeAgent
+from kg.models.graph_manager import KnowledgeGraphManager
+from agents.core.base_agent import AgentMessage
+
+
+async def main() -> None:
+    kg = KnowledgeGraphManager()
+    email_agent = VertexEmailAgent()
+    judge = JudgeAgent(kg=kg)
+    email_agent.knowledge_graph = kg
+    judge.knowledge_graph = kg
+
+    await email_agent.initialize()
+    await judge.initialize()
+
+    print(f"Initial triple count: {len(kg.graph)}")
+
+    msg = AgentMessage(
+        sender="demo",
+        recipient=email_agent.agent_id,
+        content={"recipient": "user@example.com", "subject": "Hello", "body": "Test"},
+        timestamp=0.0,
+        message_type="send_email",
+    )
+    await email_agent.process_message(msg)
+
+    decision = await judge.evaluate_challenge("email sent")
+    print(f"Judge decision: {decision}")
+
+    print(f"Final triple count: {len(kg.graph)}")
+    print("Diary entries:")
+    for entry in judge.diary:
+        print(entry)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/test_judge_agent.py
+++ b/tests/unit/test_judge_agent.py
@@ -1,0 +1,36 @@
+import pytest
+import pytest_asyncio
+
+from agents.domain.judge_agent import JudgeAgent
+from agents.domain.vertex_email_agent import VertexEmailAgent
+from agents.core.base_agent import AgentMessage
+from kg.models.graph_manager import KnowledgeGraphManager
+
+
+@pytest_asyncio.fixture
+async def setup_agents():
+    kg = KnowledgeGraphManager()
+    email_agent = VertexEmailAgent()
+    judge = JudgeAgent(kg=kg)
+    email_agent.knowledge_graph = kg
+    judge.knowledge_graph = kg
+    await email_agent.initialize()
+    await judge.initialize()
+    return email_agent, judge
+
+
+@pytest.mark.asyncio
+async def test_judge_evaluates_email(setup_agents):
+    email_agent, judge = setup_agents
+    message = AgentMessage(
+        sender="tester",
+        recipient=email_agent.agent_id,
+        content={"recipient": "user@example.com", "subject": "Hi", "body": "Test"},
+        timestamp=0.0,
+        message_type="send_email",
+    )
+    await email_agent.process_message(message)
+
+    decision = await judge.evaluate_challenge("dummy")
+    assert decision == "Approved"
+    assert judge.diary

--- a/tests/unit/test_vertex_email_agent.py
+++ b/tests/unit/test_vertex_email_agent.py
@@ -1,0 +1,30 @@
+import pytest
+import pytest_asyncio
+from agents.domain.vertex_email_agent import VertexEmailAgent
+from agents.core.base_agent import AgentMessage
+from kg.models.graph_manager import KnowledgeGraphManager
+
+@pytest_asyncio.fixture
+async def vertex_agent():
+    kg = KnowledgeGraphManager()
+    agent = VertexEmailAgent()
+    agent.knowledge_graph = kg
+    await agent.initialize()
+    return agent
+
+@pytest.mark.asyncio
+async def test_send_email(vertex_agent):
+    message = AgentMessage(
+        sender="tester",
+        recipient=vertex_agent.agent_id,
+        content={"recipient": "user@example.com", "subject": "Hi", "body": "Test"},
+        timestamp=0.0,
+        message_type="send_email",
+    )
+    response = await vertex_agent.process_message(message)
+    assert response.message_type == "send_email_response"
+    assert response.content["status"] == "sent"
+    assert len(vertex_agent.sent_emails) == 1
+    # Verify knowledge graph updated
+    data = await vertex_agent.query_knowledge_graph({"sparql": "SELECT ?s WHERE {?s ?p ?o}"})
+    assert data


### PR DESCRIPTION
## Summary
- implement `JudgeAgent` for verifying email actions
- log diary entries in `VertexEmailAgent`
- provide `demo_judge_review.py` showcasing triple counts and diary output
- export new agent and add unit test
- document demo usage in README

## Testing
- `ruff check agents/domain/judge_agent.py agents/domain/__init__.py agents/domain/vertex_email_agent.py scripts/demo_judge_review.py tests/unit/test_judge_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rdflib', 'pytest_asyncio')*
