### PR TITLE
Add scratch_space directory and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ logs/
 # OS
 .DS_Store
 Thumbs.db 
+# Scratch space
+scratch_space/*
+!scratch_space/README.md

--- a/README.md
+++ b/README.md
@@ -79,8 +79,14 @@ semant/
 │   └── schemas/          # RDF schemas
 ├── tests/                # Test suite
 ├── scripts/              # Utility scripts
+├── scratch_space/       # Local development and testing area
 └── docs/                # Documentation
-```
+``` 
+
+## Scratch Space
+The `scratch_space/` directory is provided for local experimentation. Any files
+or folders placed here are ignored by Git (except for `README.md`). Use it for
+temporary data, quick tests, or other work-in-progress artifacts.
 
 ## Development
 

--- a/scratch_space/README.md
+++ b/scratch_space/README.md
@@ -1,0 +1,6 @@
+# Scratch Space
+
+This directory is intended for development and testing artifacts.
+Feel free to create temporary files or subdirectories here.
+All contents are ignored by Git except for this README, so nothing
+placed in `scratch_space/` will be committed by default.


### PR DESCRIPTION
## Summary
- add `scratch_space` directory for local development
- ignore scratch space contents in `.gitignore`
- document scratch space usage in `README`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: rdflib)*